### PR TITLE
Add rets status and correct max rows

### DIFF
--- a/rets/client/table.py
+++ b/rets/client/table.py
@@ -55,7 +55,7 @@ _LOOKUP_TYPE = 'Lookup'
 _LOOKUP_PARSER = str
 
 _LOOKUP_MULTI_TYPES = frozenset(('LookupMulti', 'LookupBitstring', 'LookupBitmask'))
-_LOOKUP_MULTI_PARSER = lambda value: tuple(str(value).split(','))
+_LOOKUP_MULTI_PARSER = lambda value: str(value).split(',')
 
 _DATA_TYPE_PARSERS = {
     'Boolean': lambda value: value == '1',

--- a/rets/http/parsers/parse.py
+++ b/rets/http/parsers/parse.py
@@ -124,7 +124,7 @@ def parse_search(response: Response) -> SearchResult:
 
     return SearchResult(
         count=count,
-        # for some reason bool(elem.find('MAXROWS')) is incorrect
+        # python xml.etree.ElementTree.Element objects are always considered false-y
         max_rows=elem.find('MAXROWS') is not None,
         data=data,
     )

--- a/rets/http/parsers/parse.py
+++ b/rets/http/parsers/parse.py
@@ -124,7 +124,8 @@ def parse_search(response: Response) -> SearchResult:
 
     return SearchResult(
         count=count,
-        max_rows=bool(elem.find('MAXROWS')),
+        # for some reason bool(elem.find('MAXROWS')) is incorrect
+        max_rows=elem.find('MAXROWS') is not None,
         data=data,
     )
 


### PR DESCRIPTION
Rets has max row limitations, and will sometimes limit the number of results that it returns. The usual symptom here is that count > len(data)

It will indicate when this is out of sync in 2 ways 

- existence of maxrows tag
- rets-status 

This PR fixes the maxrows check and parses out rets-status when it exists 