### PR TITLE
use http post for search requests

### DIFF
--- a/rets/http/client.py
+++ b/rets/http/client.py
@@ -270,10 +270,10 @@ class RetsHttpClient:
         })
 
         if self._http_auth:
-            response = self._session.get(url, auth=self._http_auth, headers=headers, params=payload)
+            response = self._session.post(url, auth=self._http_auth, headers=headers, data=payload)
         else:
             headers['RETS-UA-Authorization'] = self._user_agent_auth_digest()
-            response = self._session.get(url, headers=headers, params=payload)
+            response = self._session.post(url, headers=headers, data=payload)
 
         response.raise_for_status()
 


### PR DESCRIPTION
Using get for search fails on GAMLS when the number of ids fetched is too big (~2000)