### PR TITLE
Enable RetsClient instantiation from metadata dict

### DIFF
--- a/rets/client/client.py
+++ b/rets/client/client.py
@@ -44,7 +44,9 @@ class RetsClient:
                  capability_urls: dict = None,
                  cookie_dict: dict = None,
                  **kwargs):
-        self.http = http_client or RetsHttpClient(*args, **kwargs)
+        self.http = http_client or RetsHttpClient(*args,
+                                                  capability_urls=capability_urls, cookie_dict=cookie_dict,
+                                                  **kwargs)
         if not (capability_urls and cookie_dict):
             self.http.login()
         self._resources = self._resources_from_metadata(metadata)

--- a/rets/client/client.py
+++ b/rets/client/client.py
@@ -21,7 +21,7 @@ class RetsClient:
         for resource in self.resources:
             if resource.name == name:
                 return resource
-        return None
+        raise KeyError('unknown resource %s' % name)
 
     def _fetch_resources(self) -> Sequence[Resource]:
         metadata = self._http.get_metadata('resource')[0].data

--- a/rets/client/object_type.py
+++ b/rets/client/object_type.py
@@ -20,6 +20,10 @@ class ObjectType:
             return self._metadata['MIMEType']
         return self._metadata['MimeType']
 
+    @property
+    def metadata(self) -> dict:
+        return dict(self._metadata)
+
     def get(self, resource_keys: Union[str, Mapping[str, Any], Sequence[str]],
             **kwargs) -> Sequence[Object]:
         return self._http.get_object(self.resource.name, self.name, resource_keys, **kwargs)

--- a/rets/client/resource.py
+++ b/rets/client/resource.py
@@ -29,7 +29,7 @@ class Resource:
         for resource_class in self.classes:
             if resource_class.name == name:
                 return resource_class
-        return None
+        raise KeyError('unknown class %s' % name)
 
     @property
     def object_types(self) -> Sequence[ObjectType]:
@@ -41,7 +41,7 @@ class Resource:
         for resource_object in self.object_types:
             if resource_object.name == name:
                 return resource_object
-        return None
+        raise KeyError('unknown object type %s' % name)
 
     def _fetch_classes(self) -> Sequence[ResourceClass]:
         metadata = self._http.get_metadata('class', resource=self.name)[0].data

--- a/rets/client/resource.py
+++ b/rets/client/resource.py
@@ -10,6 +10,8 @@ class Resource:
     def __init__(self, metadata: dict, http_client: RetsHttpClient):
         self._http = http_client
         self._metadata = metadata
+        self._classes = self._classes_from_metadata(metadata.get('_classes', ()))
+        self._object_types = self._object_types_from_metadata(metadata.get('_object_types', ()))
 
     @property
     def name(self) -> str:
@@ -20,10 +22,19 @@ class Resource:
         return self._metadata['KeyField']
 
     @property
+    def metadata(self) -> dict:
+        metadata = dict(self._metadata)
+        if self._classes:
+            metadata['_classes'] = tuple(resource_class.metadata for resource_class in self._classes)
+        if self._object_types:
+            metadata['_object_types'] = tuple(object_type.metadata for object_type in self._object_types)
+        return metadata
+
+    @property
     def classes(self) -> Sequence[ResourceClass]:
-        if '_classes' not in self._metadata:
-            self._metadata['_classes'] = self._fetch_classes()
-        return self._metadata['_classes']
+        if not self._classes:
+            self._classes = self._fetch_classes()
+        return self._classes
 
     def get_class(self, name: str) -> Optional[ResourceClass]:
         for resource_class in self.classes:
@@ -33,9 +44,9 @@ class Resource:
 
     @property
     def object_types(self) -> Sequence[ObjectType]:
-        if '_object_types' not in self._metadata:
-            self._metadata['_object_types'] = self._fetch_object_types()
-        return self._metadata['_object_types']
+        if not self._object_types:
+            self._object_types = self._fetch_object_types()
+        return self._object_types
 
     def get_object_type(self, name: str) -> Optional[ObjectType]:
         for resource_object in self.object_types:
@@ -45,11 +56,17 @@ class Resource:
 
     def _fetch_classes(self) -> Sequence[ResourceClass]:
         metadata = self._http.get_metadata('class', resource=self.name)[0].data
-        return tuple(ResourceClass(self, m, self._http) for m in metadata)
+        return self._classes_from_metadata(metadata)
 
     def _fetch_object_types(self) -> Sequence[ObjectType]:
         metadata = self._http.get_metadata('object', resource=self.name)[0].data
-        return tuple(ObjectType(self, m, self._http) for m in metadata)
+        return self._object_types_from_metadata(metadata)
+
+    def _classes_from_metadata(self, classes_metadata: Sequence[dict]) -> Sequence[ResourceClass]:
+        return tuple(ResourceClass(self, m, self._http) for m in classes_metadata)
+
+    def _object_types_from_metadata(self, object_types_metadata: Sequence[dict]) -> Sequence[ObjectType]:
+        return tuple(ObjectType(self, m, self._http) for m in object_types_metadata)
 
     def __repr__(self) -> str:
         return '<Resource: %s>' % self.name

--- a/rets/client/table.py
+++ b/rets/client/table.py
@@ -21,6 +21,10 @@ class Table:
         }
 
     @property
+    def metadata(self) -> Sequence[dict]:
+        return tuple(self._fields)
+
+    @property
     def fields(self) -> Set[str]:
         return set(self._parsers)
 

--- a/rets/http/client.py
+++ b/rets/http/client.py
@@ -27,6 +27,7 @@ class RetsHttpClient:
                  user_agent: str = 'rets-python/0.3',
                  user_agent_password: str = None,
                  rets_version: str = '1.7.2',
+                 capability_urls: str = None,
                  cookie_dict: dict = None
                  ):
         self._user_agent = user_agent
@@ -35,7 +36,7 @@ class RetsHttpClient:
 
         splits = urlsplit(login_url)
         self._base_url = urlunsplit((splits.scheme, splits.netloc, '', '', ''))
-        self._capabilities = {
+        self._capabilities = capability_urls or {
             'Login': splits.path,
         }
 
@@ -46,13 +47,14 @@ class RetsHttpClient:
             self._http_auth = None
 
         # we use a session to keep track of cookies that are required for certain MLSes
-        self._session = None
+        self._session = requests.Session()
 
         # The user may provide an optional cookie_dict argument, which will be used on first login.
         # When sending cookies (with a session_id) to the login url, the same cookie (session_id)
-        # is returned, which (most likely) means no additional login is created. On logout,
-        # this str is destroyed, and login will fetch a new cookies
-        self._cookie_dict = cookie_dict
+        # is returned, which (most likely) means no additional login is created.
+        if cookie_dict:
+            for name, value in cookie_dict.items():
+                self._session.cookies.set(name, value=value)
 
         # this session id is part of the rets standard for use with a user agent password
         self._rets_session_id = ''
@@ -78,12 +80,15 @@ class RetsHttpClient:
         """
         return 'RETS/' + self._rets_version
 
-    def login(self) -> dict:
-        self._session = requests.Session()
-        if self._cookie_dict:
-            for name, value in self._cookie_dict.items():
-                self._session.cookies.set(name, value=value)
+    @property
+    def capability_urls(self) -> dict:
+        return self._capabilities
 
+    @property
+    def cookie_dict(self) -> dict:
+        return dict(self._session.cookies)
+
+    def login(self) -> dict:
         response = self._http_post(self._url_for('Login'))
         self._capabilities = parse_capability_urls(response)
         return self._capabilities
@@ -91,7 +96,6 @@ class RetsHttpClient:
     def logout(self) -> None:
         self._http_post(self._url_for('Logout'))
         self._session = None
-        self._cookie_dict = None
 
     def get_system_metadata(self) -> SystemMetadata:
         return parse_system(self._get_metadata('system'))


### PR DESCRIPTION
So we can avoid unnecessary login and get_metadata transactions if we already have the session cookie, capability URLs, and the metadata.