### PR TITLE
Revise supported versions to 3.5 or later

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,4 +16,3 @@ optional_value = gamma
 values = 
 	gamma
 	dev
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 
 python:
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # RETS Python 3 Client
 
-Python 3 client for the Real Estate Transaction Standard (RETS) Version 1.7.2. Supports Python 3.3 or later.
+Python 3 client for the Real Estate Transaction Standard (RETS) Version 1.7.2. Supports Python 3.5 or later.
 
 ```
 pip install rets-python

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3, 3):
-    print('rets requires Python 3.3 or later')
+if sys.version_info < (3, 5):
+    print('rets requires Python 3.5 or later')
     sys.exit(1)
 
 
@@ -50,8 +50,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',


### PR DESCRIPTION
Because the `typing` module was only added in 3.5. 