### PR TITLE
Import cgi from standard library instead of requests

### DIFF
--- a/rets/http/parsers/parse_object.py
+++ b/rets/http/parsers/parse_object.py
@@ -1,9 +1,9 @@
 import mimetypes
 from typing import Optional, Sequence
+import cgi
 
 from requests import Response
 from requests.structures import CaseInsensitiveDict
-from requests.utils import cgi
 from requests_toolbelt.multipart.decoder import MultipartDecoder
 
 from rets.errors import RetsApiError, RetsParseError


### PR DESCRIPTION
Latest version of requests no longer has cgi module. Requests was just importing cgi from the standard library anyway.