### PR TITLE
Replace space with `T` for datetime parser

### DIFF
--- a/rets/client/decoder.py
+++ b/rets/client/decoder.py
@@ -67,6 +67,9 @@ def _get_decoder(data_type: str, interpretation: str, include_tz: bool = False):
 
 
 def _decode_datetime(value: str, include_tz: bool) -> datetime:
+    # Correct `0000-00-00 00:00` to `0000-00-00T00:00`
+    if value[10] == ' ':
+        value = '%sT%s' % (value[0:10], value[11:])
     decoded = udatetime.from_string(value)
     if not include_tz:
         return decoded.astimezone(timezone.utc).replace(tzinfo=None)

--- a/tests/client/decoder_test.py
+++ b/tests/client/decoder_test.py
@@ -123,6 +123,7 @@ def test_decode_datetime():
     assert _decode_datetime('2017-01-02T03:04:05-00:00', False) == datetime(2017, 1, 2, 3, 4, 5)
     assert _decode_datetime('2017-01-02T12:00:00+07:08', False) == datetime(2017, 1, 2, 4, 52)
     assert _decode_datetime('2017-01-02T12:00:00-07:08', False) == datetime(2017, 1, 2, 19, 8)
+    assert _decode_datetime('2017-01-01 00:00:00', False) == datetime(2017, 1, 1, 0, 0)
 
 
 def test_decode_time():


### PR DESCRIPTION
Running into an MLS that formats the dates differently to the specification by using a space separator. This is a quick fix to ensure the parser continues working here and haven't worried about entirely incorrect formats that might encounter a space here because `udatetime` strictly adheres to RFC3339, so it shouldn't be possible for the 1 character change to result in a valid datetime except in this scenario.