### PR TITLE
Fix the version of the udatetime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_desc = 'Python 3 client for the Real Estate Transaction Standard (RETS) Ver
 install_requires = [
     'requests>=2.12.3',
     'requests-toolbelt>=0.7.0',
-    'udatetime>=0.0.11',
+    'udatetime==0.0.16',
     'docopts',
 ]
 


### PR DESCRIPTION
Old version can't parse:
udatetime.from_string('2018-08-21T21:06:06.2')