### PR TITLE
Raise error on invalid `content-type` response

### DIFF
--- a/rets/errors.py
+++ b/rets/errors.py
@@ -18,3 +18,11 @@ class RetsApiError(RetsClientError):
         self.reply_code = reply_code
         self.reply_text = reply_text
         self.xml = xml
+
+
+class RetsContentTypeError(RetsClientError):
+
+    def __init__(self, content: str, headers: dict):
+        super().__init__('Unexpected content type in response')
+        self.content = content
+        self.headers = headers

--- a/tests/http/parsers/parse_object_test.py
+++ b/tests/http/parsers/parse_object_test.py
@@ -1,6 +1,6 @@
 from requests.structures import CaseInsensitiveDict
 from rets import Object
-from rets.http.parsers.parse_object import parse_object, _guess_mime_type
+from rets.http.parsers.parse_object import parse_object, _guess_mime_type, _parse_mime_type
 from tests.utils import make_response
 
 
@@ -227,19 +227,15 @@ def test_parse_object_location_true_content_type_xml():
 
 def test_guess_mime_type():
     # Can guess from URL extension
-    assert 'image/jpeg' == _guess_mime_type(CaseInsensitiveDict({'Location': 'http://cdn.rets.com/1.jpg'}))
-    assert 'image/png' == _guess_mime_type(CaseInsensitiveDict({'Location': 'http://cdn.rets.com/1.png'}))
-    assert 'application/pdf' == _guess_mime_type(CaseInsensitiveDict({'Location': 'http://cdn.rets.com/1.pdf'}))
+    assert 'image/jpeg' == _guess_mime_type('http://cdn.rets.com/1.jpg')
+    assert 'image/png' == _guess_mime_type('http://cdn.rets.com/1.png')
+    assert 'application/pdf' == _guess_mime_type('http://cdn.rets.com/1.pdf')
 
     # Can guess from content type if extension is missing
-    assert 'image/jpeg' == _guess_mime_type(CaseInsensitiveDict({
-        'Location': 'http://cdn.rets.com/1',
-        'Content-Type': 'image/jpeg',
-    }))
+    assert 'image/jpeg' == _guess_mime_type('http://cdn.rets.com/1', 'image/jpeg')
 
     # Can guess from content type
-    assert 'image/jpeg' == _guess_mime_type(CaseInsensitiveDict({'Content-Type': 'image/jpeg'}))
-    assert 'image/jpeg' == _guess_mime_type(CaseInsensitiveDict({'Content-Type': 'image/jpeg;charset=US-ASCII'}))
+    assert 'image/jpeg' == _parse_mime_type('image/jpeg')
+    assert 'image/jpeg' == _parse_mime_type('image/jpeg;charset=US-ASCII')
 
-    assert None == _guess_mime_type(CaseInsensitiveDict({'Content-Type': ''}))
-    assert None == _guess_mime_type(CaseInsensitiveDict())
+    assert None == _guess_mime_type('')


### PR DESCRIPTION
Raise a catchable error when `headers['content-type']` is missing. While reviewing the code, I split the `Location` header response to exit earlier since the `content-type` header is not required on that code path. The next part will do the usual checks but also verify we have a `content-type` header. If not, we raise a `RetsContentTypeError` that contains the response and headers for easier debugging. 