### PR TITLE
Add error for missing `content-id` or `object-id`

### DIFF
--- a/rets/errors.py
+++ b/rets/errors.py
@@ -11,6 +11,14 @@ class RetsParseError(RetsClientError):
     pass
 
 
+class RetsResponseError(RetsClientError):
+
+    def __init__(self, content: str, headers: dict):
+        super().__init__('Unexpected response from RETS')
+        self.content = content
+        self.headers = headers
+
+
 class RetsApiError(RetsClientError):
 
     def __init__(self, reply_code: int, reply_text: str, xml: str):
@@ -18,11 +26,3 @@ class RetsApiError(RetsClientError):
         self.reply_code = reply_code
         self.reply_text = reply_text
         self.xml = xml
-
-
-class RetsContentTypeError(RetsClientError):
-
-    def __init__(self, content: str, headers: dict):
-        super().__init__('Unexpected content type in response')
-        self.content = content
-        self.headers = headers


### PR DESCRIPTION
Following up on https://github.com/opendoor-labs/rets/pull/35 to handle other missing required headers.