### PR TITLE
Add Timestamp support in decoders dict because sometimes we need it f…

### DIFF
--- a/rets/client/decoder.py
+++ b/rets/client/decoder.py
@@ -107,4 +107,5 @@ _DECODERS = {
     'Int': int,
     'Long': int,
     'Decimal': Decimal,
+    'Timestamp': datetime.now()
 }


### PR DESCRIPTION
Add Timestamp support in decoders dict, because sometimes we need it for queries, for example query for CREA is LastUpdated=2015-09-01T00:00:00Z