### PR TITLE
Add support for Number types

### DIFF
--- a/rets/client/decoder.py
+++ b/rets/client/decoder.py
@@ -112,4 +112,5 @@ _DECODERS = {
     'Int': int,
     'Long': int,
     'Decimal': Decimal,
+    'Number': int,
 }

--- a/tests/client/decoder_test.py
+++ b/tests/client/decoder_test.py
@@ -95,6 +95,9 @@ def test_get_decoder():
     parser = _get_decoder('Character', 'LookupMulti')
     assert parser('a,b,c') == ['a', 'b', 'c']
 
+    parser = _get_decoder('Number', '')
+    assert parser('214') == 214
+
 
 def test_decode_datetime():
     assert _decode_datetime('2017-01-02T03:04:05', True) == \


### PR DESCRIPTION
CARETS uses Number types in their columns which are just integers. This change adds support for them.