### PR TITLE
Use `lxml` to parse XML and handle invalid characters

### DIFF
--- a/rets/http/parsers/parse.py
+++ b/rets/http/parsers/parse.py
@@ -6,7 +6,7 @@ from lxml import etree
 from requests import Response
 from requests_toolbelt.multipart.decoder import BodyPart
 
-from rets.errors import RetsParseError, RetsApiError
+from rets.errors import RetsParseError, RetsApiError, RetsResponseError
 from rets.http.data import Metadata, SearchResult, SystemMetadata
 
 DEFAULT_ENCODING = 'utf-8'
@@ -18,7 +18,7 @@ def parse_xml(response: ResponseLike) -> etree.Element:
     root = etree.fromstring(response.content.decode(DEFAULT_ENCODING), parser=etree.XMLParser(recover=True))
 
     if root is None:
-        raise RetsApiError(500, "Could not parse response from RETS", response.content)
+        raise RetsResponseError(response.content, response.headers)
 
     reply_code, reply_text = _parse_rets_status(root)
     if reply_code and reply_text != "Operation Successful":

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ install_requires = [
     'requests-toolbelt>=0.7.0',
     'udatetime==0.0.16',
     'docopts',
+    'lxml>=4.3.0',
 ]
 
 setup_requires = [

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_desc = 'Python 3 client for the Real Estate Transaction Standard (RETS) Ver
 
 install_requires = [
     'requests>=2.12.3',
-    'requests-toolbelt>=0.7.0',
+    'requests-toolbelt>=0.7.0,!=0.9.0',
     'udatetime==0.0.16',
     'docopts',
     'lxml>=4.3.0',


### PR DESCRIPTION
While parsing some data from CARETS, we found a few invalid characters in the data that the basic XML parser couldn't handle. This change switches the parser to use `lxml` and skip invalid characters.