### PR TITLE
Fix metadata request and use all authentications if passwords are provided

### DIFF
--- a/rets/http/client.py
+++ b/rets/http/client.py
@@ -303,9 +303,9 @@ class RetsHttpClient:
         if self._use_get_method:
             if payload:
                 url = '%s?%s' % (url, urlencode(payload))
-            response = self._http_get(url, auth=self._http_auth, headers=request_headers)
+            response = self._session.get(url, auth=self._http_auth, headers=request_headers)
         else:
-            response = self._http_post(url, auth=self._http_auth, headers=request_headers, payload=payload)
+            response = self._session.post(url, auth=self._http_auth, headers=request_headers, data=payload)
 
         response.raise_for_status()
         self._rets_session_id = response.cookies.get('RETS-Session-ID', '')

--- a/rets/http/client.py
+++ b/rets/http/client.py
@@ -139,8 +139,8 @@ class RetsHttpClient:
             Note: The metadata_id for METADATA-SYSTEM and METADATA-RESOURCE must be 0 or *.
         """
         payload = {
-            'type': 'METADATA-' + type_.upper(),
-            'id': metadata_id,
+            'Type': 'METADATA-' + type_.upper(),
+            'ID': metadata_id,
             'Format': 'COMPACT',
         }
         return self._http_request(self._url_for('GetMetadata'), payload=payload)

--- a/rets/http/client.py
+++ b/rets/http/client.py
@@ -308,7 +308,7 @@ class RetsHttpClient:
             response = self._session.post(url, auth=self._http_auth, headers=request_headers, data=payload)
 
         response.raise_for_status()
-        self._rets_session_id = response.cookies.get('RETS-Session-ID', '')
+        self._rets_session_id = self._session.cookies.get('RETS-Session-ID', '')
         return response
 
     def _rets_ua_authorization(self) -> str:


### PR DESCRIPTION
Title-cased keys for metadata requests are declared in RETS standard (https://www.nar.realtor/retsorg.nsf/retsproto1.7d6.pdf section 11.1.2) and were necessary for Victoria MLS RETS feed.
Both authentication methods were necessary for Paragon RETS feed (http://paragonconnect.paragonrels.com/rets/user-and-password-availability).
Fix UA authentication (add missing _Digest _ and fix missing session ID)