### PR TITLE
Handle `20502` in response for invalid metadata

### DIFF
--- a/rets/http/client.py
+++ b/rets/http/client.py
@@ -121,7 +121,7 @@ class RetsHttpClient:
         try:
             return parse_metadata(self._get_metadata(type_, id_))
         except RetsApiError as e:
-            if e.reply_code == 20503:  # No Metadata found
+            if e.reply_code in (20502, 20503):  # No metadata exists.
                 return ()
             raise
 


### PR DESCRIPTION
We found realtracs is responding with a `20502` ("Invalid Identifier" - The identifier is not known inside the specified resource) when asking for metadata that doesn't exist (e.g. `METADATA-OBJECT` on `Agent` resource). Another workaround we should consider moving to is asking for `:*` (all resources) instead of a specific resource - it may optimize the number of round trip HTTP requets.