### PR TITLE
Allow strict handling of XML reply codes

### DIFF
--- a/tests/http/parsers/parse_multipart_test.py
+++ b/tests/http/parsers/parse_multipart_test.py
@@ -15,7 +15,7 @@ def test_parse_object_single_location_true():
     body = b''
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='20170817170218718581000000',
@@ -39,7 +39,7 @@ def test_parse_object_single_location_false():
     body = b'binary content'
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='20170817170218718581000000',
@@ -62,7 +62,7 @@ def test_parse_object_not_found():
     body = b'<RETS ReplyCode="20403" ReplyText="No such object available for this resource"/>'
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == ()
+    assert parse_object(response, False) == ()
 
 
 def test_parse_object_multi_location_true():
@@ -91,7 +91,7 @@ def test_parse_object_multi_location_true():
     )
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='20170817170218718581000000',
@@ -139,7 +139,7 @@ def test_parse_object_multi_location_false():
     )
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='20170817170218718581000000',
@@ -180,7 +180,7 @@ def test_parse_object_no_encoding():
     )
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='20170817170218718581000000',
@@ -211,7 +211,7 @@ def test_parse_object_location_true_content_type_xml():
     )
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='8240151',

--- a/tests/http/parsers/parse_object_test.py
+++ b/tests/http/parsers/parse_object_test.py
@@ -16,7 +16,7 @@ def test_parse_object_single_location_true():
     body = b''
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='20170817170218718581000000',
@@ -40,7 +40,7 @@ def test_parse_object_single_location_false():
     body = b'binary content'
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='20170817170218718581000000',
@@ -63,7 +63,7 @@ def test_parse_object_not_found():
     body = b'<RETS ReplyCode="20403" ReplyText="No such object available for this resource"/>'
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == ()
+    assert parse_object(response, False) == ()
 
 
 def test_parse_object_multi_location_true():
@@ -92,7 +92,7 @@ def test_parse_object_multi_location_true():
     )
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='20170817170218718581000000',
@@ -140,7 +140,7 @@ def test_parse_object_multi_location_false():
     )
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='20170817170218718581000000',
@@ -181,7 +181,7 @@ def test_parse_object_no_encoding():
     )
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='20170817170218718581000000',
@@ -212,7 +212,7 @@ def test_parse_object_location_true_content_type_xml():
     )
     response = make_response(200, body, headers)
 
-    assert parse_object(response) == (
+    assert parse_object(response, False) == (
         Object(
             mime_type='image/jpeg',
             content_id='8240151',


### PR DESCRIPTION
It's possible to receive a reply code of 20208 when we request too much data from the RETS server, but the operation is still returned successfully. Add a mode that'll raise on this code, but keep it behind a flag for backward compatibility.