### PR TITLE
Use response encoding with fallback to default

### DIFF
--- a/rets/http/parsers/parse.py
+++ b/rets/http/parsers/parse.py
@@ -15,7 +15,8 @@ ResponseLike = Union[Response, BodyPart]
 
 
 def parse_xml(response: ResponseLike) -> etree.Element:
-    root = etree.fromstring(response.content.decode(DEFAULT_ENCODING), parser=etree.XMLParser(recover=True))
+    encoding = response.encoding or DEFAULT_ENCODING
+    root = etree.fromstring(response.content.decode(encoding), parser=etree.XMLParser(recover=True))
 
     if root is None:
         raise RetsResponseError(response.content, response.headers)


### PR DESCRIPTION
I had an issue with KAR (Kootenay) RETS feed, where parsing failed on character 0xae (register mark in latin-1 encoding). This change fixed the issue, it's similar to this fix: https://github.com/opendoor-labs/rets/pull/17/files
