### PR TITLE
Delete resource key from record

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,6 @@ The values returned by the search query will be automatically decoded into Pytho
 ```python
 >>> listing = search_result.data[0]
 
->>> listing.resource_key
-'20170104191513476022000000'
-
 >>> listing.data
 {
     'internal_listing_id': '20170104191513476022000000',
@@ -79,17 +76,16 @@ The values returned by the search query will be automatically decoded into Pytho
     'list_price': 250000,
     ...
 }
+
+>>> listing.data[listing.resource_class.resource.key_field]
+'20170104191513476022000000'
 ```
 
-Photos and other object types for a record can be retrieved directly from the record object. They
-can also be retrieved in bulk from the ObjectType object using the resource keys of the records.
+Photos can also be retrieved in bulk from the ObjectType object using the resource keys of the records.
 
 ```python
->>> listing.get_objects('HiRes', location=True)
-(Object(mime_type='image/jpeg', content_id='20170104191513476022000000', description='Front', object_id='1', url='...', preferred=True, data=None), ...)
-
 >>> all_photos = photo_object_type.get(
-    resource_keys=[listing.resource_key for listing in listings],
+    resource_keys=[listing.data[listing.resource_class.resource.key_field] for listing in listings],
     location=True,
 )
 

--- a/rets/client/record.py
+++ b/rets/client/record.py
@@ -6,18 +6,11 @@ from rets.http import Object
 class Record:
 
     def __init__(self, resource_class, data: dict):
-        self.resource = resource_class.resource
         self.resource_class = resource_class
-        self.resource_key = str(data[resource_class.resource.key_field])
         self.data = data
 
-    def get_objects(self, name: str, **kwargs) -> Sequence[Object]:
-        resource_object = self.resource.get_object_type(name)
-        return resource_object.get(self.resource_key, **kwargs)
-
     def __repr__(self) -> str:
-        return '<Record: %s:%s:%s>' % (
+        return '<Record: %s:%s>' % (
             self.resource_class.resource.name,
             self.resource_class.name,
-            self.resource_key,
         )


### PR DESCRIPTION
There's been a few instances where the MLS `KeyField` has been incorrect and we need to override internally, using long hand accessors would avoid having to adds hacks around the automatic metadata usage in `rets`.