### PR TITLE
use dateutil parser for datetime parsing

### DIFF
--- a/rets/client/decoder.py
+++ b/rets/client/decoder.py
@@ -7,6 +7,7 @@ from functools import partial
 from typing import Any, Sequence
 
 import udatetime
+import dateutil
 
 from rets.errors import RetsParseError
 
@@ -68,14 +69,7 @@ def _get_decoder(data_type: str, interpretation: str, include_tz: bool = False):
 
 
 def _decode_datetime(value: str, include_tz: bool) -> datetime:
-    # Correct `0000-00-00 00:00:00` to `0000-00-00T00:00:00`
-    if re.match(r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$', value):
-        value = '%sT%s' % (value[0:10], value[11:])
-    # Correct `0000-00-00` to `0000-00-00T00:00:00`
-    elif re.match(r'^\d{4}-\d{2}-\d{2}$', value):
-        value = '%sT00:00:00' % value[0:10]
-
-    decoded = udatetime.from_string(value)
+    decoded = dateutil.parser.parse(value)
     if not include_tz:
         return decoded.astimezone(timezone.utc).replace(tzinfo=None)
     return decoded

--- a/rets/client/decoder.py
+++ b/rets/client/decoder.py
@@ -7,7 +7,6 @@ from functools import partial
 from typing import Any, Sequence
 
 import udatetime
-import dateutil
 
 from rets.errors import RetsParseError
 
@@ -69,7 +68,14 @@ def _get_decoder(data_type: str, interpretation: str, include_tz: bool = False):
 
 
 def _decode_datetime(value: str, include_tz: bool) -> datetime:
-    decoded = dateutil.parser.parse(value)
+    # Correct `0000-00-00 00:00:00` to `0000-00-00T00:00:00`
+    if re.match(r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$', value):
+        value = '%sT%s' % (value[0:10], value[11:])
+    # Correct `0000-00-00` to `0000-00-00T00:00:00`
+    elif re.match(r'^\d{4}-\d{2}-\d{2}$', value):
+        value = '%sT00:00:00' % value[0:10]
+
+    decoded = udatetime.from_string(value)
     if not include_tz:
         return decoded.astimezone(timezone.utc).replace(tzinfo=None)
     return decoded

--- a/rets/client/decoder.py
+++ b/rets/client/decoder.py
@@ -69,7 +69,7 @@ def _get_decoder(data_type: str, interpretation: str, include_tz: bool = False):
 
 def _decode_datetime(value: str, include_tz: bool) -> datetime:
     # Correct `0000-00-00 00:00:00` to `0000-00-00T00:00:00`
-    if re.match(r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$', value):
+    if value[10] == ' ':
         value = '%sT%s' % (value[0:10], value[11:])
     # Correct `0000-00-00` to `0000-00-00T00:00:00`
     elif re.match(r'^\d{4}-\d{2}-\d{2}$', value):

--- a/tests/client/decoder_test.py
+++ b/tests/client/decoder_test.py
@@ -106,6 +106,8 @@ def test_decode_datetime():
     # digit, however udatetime only permits 3 or 6 digits.
     assert _decode_datetime('2017-01-02T03:04:05.600', True) == \
            datetime(2017, 1, 2, 3, 4, 5, 600000, tzinfo=timezone(timedelta(0)))
+    assert _decode_datetime('2020-10-12 10:46:54.146488', True) == \
+           datetime(2020, 10, 12, 10, 46, 54, 146488, tzinfo=timezone(timedelta(0)))
     assert _decode_datetime('2017-01-02T03:04:05Z', True) == \
            datetime(2017, 1, 2, 3, 4, 5, tzinfo=timezone(timedelta(0)))
     assert _decode_datetime('2017-01-02T03:04:05+00:00', True) == \


### PR DESCRIPTION
the old regex wouldn't parse a datetime like: `2020-10-12 10:46:54.146488`
also, the regex is complicated and unnecessary

I replaced it to use `datetuil.parse()` which should handle everything. this was a suggestion from another pr, but not implemented because the suggestion was left after the pr was merged
https://github.com/opendoor-labs/rets/pull/41/files