### PR TITLE
Fix date from RETS

### DIFF
--- a/rets/client/decoder.py
+++ b/rets/client/decoder.py
@@ -68,12 +68,12 @@ def _get_decoder(data_type: str, interpretation: str, include_tz: bool = False):
 
 
 def _decode_datetime(value: str, include_tz: bool) -> datetime:
-    # Correct `0000-00-00 00:00:00` to `0000-00-00T00:00:00`
-    if value[10] == ' ':
-        value = '%sT%s' % (value[0:10], value[11:])
     # Correct `0000-00-00` to `0000-00-00T00:00:00`
-    elif re.match(r'^\d{4}-\d{2}-\d{2}$', value):
+    if len(value) == 10:
         value = '%sT00:00:00' % value[0:10]
+    # Correct `0000-00-00 00:00:00` to `0000-00-00T00:00:00`
+    elif value[10] == ' ':
+        value = '%sT%s' % (value[0:10], value[11:])
 
     decoded = udatetime.from_string(value)
     if not include_tz:
@@ -114,5 +114,5 @@ _DECODERS = {
     'Decimal': Decimal,
     'Number': int,
     # Point is new "Edm.GeographyPoint" from RESO, look online for spec. Can store as Postgres Point, see https://bit.ly/2BDPgUS
-    'Point': str,  
+    'Point': str,
 }

--- a/tests/client/decoder_test.py
+++ b/tests/client/decoder_test.py
@@ -124,6 +124,8 @@ def test_decode_datetime():
            datetime(2017, 1, 2, 3, 4, 5)
     assert _decode_datetime('2017-01-02T03:04:05.600', False) == \
            datetime(2017, 1, 2, 3, 4, 5, 600000)
+    assert _decode_datetime('2017-01-02 03:04:05.600', False) == \
+           datetime(2017, 1, 2, 3, 4, 5, 600000)
     assert _decode_datetime('2017-01-02T03:04:05Z', False) == datetime(2017, 1, 2, 3, 4, 5)
     assert _decode_datetime('2017-01-02T03:04:05+00:00', False) == datetime(2017, 1, 2, 3, 4, 5)
     assert _decode_datetime('2017-01-02T03:04:05-00:00', False) == datetime(2017, 1, 2, 3, 4, 5)


### PR DESCRIPTION
Follow up to https://github.com/opendoor-labs/rets/pull/57. Index 10 may be out of range (due to the check below it). Invert the checks instead, adding the time then checking for a space.