### PR TITLE
Update error message when decoding wrong data type

### DIFF
--- a/rets/client/decoder.py
+++ b/rets/client/decoder.py
@@ -29,7 +29,10 @@ class RecordDecoder:
         def decode_field(field: str, value: str) -> Any:
             if value == '':
                 return None
-            return decoders[field](value)
+            try:
+                return decoders[field](value)
+            except Exception as e:
+                raise ValueError(f"Error decoding field {field} with value {value}. Error: {e}") from e
 
         return tuple(OrderedDict((field, decode_field(field, value)) for field, value in row.items())
                      for row in rows)


### PR DESCRIPTION
Now we know the field `ORM4_WID` that's problematic.

Old error
`invalid literal for int() with base 10: '5.6'`

new error:
`ValueError: Error decoding field ORM4_WID with value 5.6. Error: invalid literal for int() with base 10: '5.6'`