### PR TITLE
Option to not pass 'RETS-UA-Authorization', and parse non-utf8 xml

### DIFF
--- a/rets/http/client.py
+++ b/rets/http/client.py
@@ -301,7 +301,7 @@ class RetsHttpClient:
             'RETS-Version': self.rets_version,
         }
         if self._send_rets_ua_authorization:
-            request_headers['RETS-UA-Authorization']: self._rets_ua_authorization()
+            request_headers['RETS-UA-Authorization'] = self._rets_ua_authorization()
 
         if self._use_get_method:
             if payload:

--- a/rets/http/client.py
+++ b/rets/http/client.py
@@ -30,11 +30,13 @@ class RetsHttpClient:
                  capability_urls: str = None,
                  cookie_dict: dict = None,
                  use_get_method: bool = False,
+                 send_rets_ua_authorization: bool = True,
                  ):
         self._user_agent = user_agent
         self._user_agent_password = user_agent_password
         self._rets_version = rets_version
         self._use_get_method = use_get_method
+        self._send_rets_ua_authorization = send_rets_ua_authorization
 
         splits = urlsplit(login_url)
         self._base_url = urlunsplit((splits.scheme, splits.netloc, '', '', ''))
@@ -297,8 +299,9 @@ class RetsHttpClient:
             **(headers or {}),
             'User-Agent': self.user_agent,
             'RETS-Version': self.rets_version,
-            'RETS-UA-Authorization': self._rets_ua_authorization()
         }
+        if self._send_rets_ua_authorization:
+            request_headers['RETS-UA-Authorization']: self._rets_ua_authorization()
 
         if self._use_get_method:
             if payload:

--- a/rets/http/parsers/parse.py
+++ b/rets/http/parsers/parse.py
@@ -16,7 +16,18 @@ ResponseLike = Union[Response, BodyPart]
 
 def parse_xml(response: ResponseLike) -> etree.Element:
     encoding = response.encoding or DEFAULT_ENCODING
-    root = etree.fromstring(response.content.decode(encoding), parser=etree.XMLParser(recover=True))
+    try:
+        root = etree.fromstring(response.content.decode(encoding), parser=etree.XMLParser(recover=True))
+    except ValueError as e:
+        if str(e) == "Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.":
+            try:
+                # try to parse bytes directly, rather than from string
+                root = etree.XML(response.content)
+            except Exception:
+                # unable to parse bytes. abort, and re-raise original error
+                raise e
+        else:
+            raise e
 
     if root is None:
         raise RetsResponseError(response.content, response.headers)

--- a/rets/http/parsers/parse.py
+++ b/rets/http/parsers/parse.py
@@ -20,12 +20,8 @@ def parse_xml(response: ResponseLike) -> etree.Element:
         root = etree.fromstring(response.content.decode(encoding), parser=etree.XMLParser(recover=True))
     except ValueError as e:
         if str(e) == "Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.":
-            try:
-                # try to parse bytes directly, rather than from string
-                root = etree.XML(response.content)
-            except Exception:
-                # unable to parse bytes. abort, and re-raise original error
-                raise e
+            # parse bytes directly, rather than from string
+            root = etree.XML(response.content)
         else:
             raise e
 

--- a/tests/client/request_test.py
+++ b/tests/client/request_test.py
@@ -12,7 +12,6 @@ def test_rets_ua_authorization_false():
                             username='user',
                             password='pass',
                             send_rets_ua_authorization=send_auth,
-                            use_get_method=False,
                             )
     client._session = MagicMock()
     client._http_request(url='test.url')
@@ -23,19 +22,14 @@ def test_rets_ua_authorization_false():
     assert 'RETS-UA-Authorization' not in client._session.post.call_args_list[0][1]['headers']
 
 
-def test_rets_ua_authorization_true():
-    send_auth = True
-
+def test_rets_ua_authorization_default():
+    # by default, sends 'RETS-UA-Authorization'
     client = RetsHttpClient(login_url='test.url',
                             username='user',
                             password='pass',
-                            send_rets_ua_authorization=send_auth,
-                            use_get_method=False,
                             )
     client._session = MagicMock()
     client._http_request(url='test.url')
-
-    assert client._send_rets_ua_authorization == send_auth
 
     assert client._session.post.called
     assert 'RETS-UA-Authorization' in client._session.post.call_args_list[0][1]['headers']

--- a/tests/client/request_test.py
+++ b/tests/client/request_test.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock, call
+
+from rets.http.client import (
+    RetsHttpClient
+)
+
+
+def test_rets_ua_authorization_false():
+    send_auth = False
+
+    client = RetsHttpClient(login_url='test.url',
+                            username='user',
+                            password='pass',
+                            send_rets_ua_authorization=send_auth,
+                            use_get_method=False,
+                            )
+    client._session = MagicMock()
+    client._http_request(url='test.url')
+
+    assert client._send_rets_ua_authorization == send_auth
+
+    assert client._session.post.called
+    assert 'RETS-UA-Authorization' not in client._session.post.call_args_list[0][1]['headers']
+
+
+def test_rets_ua_authorization_true():
+    send_auth = True
+
+    client = RetsHttpClient(login_url='test.url',
+                            username='user',
+                            password='pass',
+                            send_rets_ua_authorization=send_auth,
+                            use_get_method=False,
+                            )
+    client._session = MagicMock()
+    client._http_request(url='test.url')
+
+    assert client._send_rets_ua_authorization == send_auth
+
+    assert client._session.post.called
+    assert 'RETS-UA-Authorization' in client._session.post.call_args_list[0][1]['headers']


### PR DESCRIPTION
I found one MLS RETS implementations will raise an error if you pass `RETS-UA-Authorization` where there is a User-Agent but not a User-Agent-Password. Most MLS don't have an issue with it, so default should be to send RETS-UA-Authorization.

Additionally, this MLS also returns non-standard encoding in case of errors, but otherwise returns standard non-problematic encoding if the response is normal. Therefore, I added an exception in the case of non-standard response to parse it as raw binary, which is successful.

Details from RETS 1.7.2 specification regarding RETS-UA-Authorization:
<img width="621" alt="Screen Shot 2021-06-03 at 11 53 05 PM" src="https://user-images.githubusercontent.com/9601962/120759594-061d0300-c4c8-11eb-81b9-6886b40792f6.png">
<img width="737" alt="Screen Shot 2021-06-03 at 11 55 21 PM" src="https://user-images.githubusercontent.com/9601962/120759589-03221280-c4c8-11eb-840f-48dcffa467c1.png">


### testing passes:

<img width="1208" alt="Screen Shot 2021-06-04 at 12 42 25 AM" src="https://user-images.githubusercontent.com/9601962/120765161-c6f1b080-c4cd-11eb-8c7a-2190803106f7.png">
