### PR TITLE
remove docopts from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ install_requires = [
     'requests>=2.12.3',
     'requests-toolbelt>=0.7.0,!=0.9.0',
     'udatetime==0.0.16',
-    'docopts',
     'lxml>=4.3.0',
 ]
 


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

There is a dependency in `install_requires` in `setup.py` on `docopts`, but this package is not at all dependent on `docopts`. It is only lightly used in `bin/deploy` script which is not part of the library itself.

This causes problems in some popular dependency resolvers like [`pip-compile`](https://github.com/jazzband/pip-tools) as [`docopts`](https://github.com/docopt/docopts) moved from Python to Go in v0.6.2 and stopped publishing packages to PyPI. The unnecessary dependency on `docopts` Python package here brings in v0.6.1 which also brings in a pinned dependency on [`docopt`](https://github.com/docopt/docopt) (no 's') v0.6.1, which has been outdated since 2014 with v0.6.2 release.

Therefore, using any other Python library that depends on `docopt > 0.6.1` cannot be used alongside `rets-python` without causing conflicts in `pip-compile`.

Can `docopts` be removed from `install_requires` as it is not actually a dependency of the library?

## Origin

Me (https://github.com/opendoor-labs/rets/issues/62)

## Summary of Changes

Remove unnecessary `docopts` dependency from `install_requires`.

## Test Plan

There is no effect on the library. The dependency is only used in the `bin/release` script.

## Checklist

<!-- This is a checklist. To mark an item as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to external documentation if necessary (READMEs, Confluence, etc.)
- [X] I have checked that other PRs this PR depends on have already been deployed.

<!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->
