### PR TITLE
Feature/parameterize response encoding

### DIFF
--- a/rets/client/decoder.py
+++ b/rets/client/decoder.py
@@ -6,8 +6,6 @@ from decimal import Decimal
 from functools import partial
 from typing import Any, Sequence
 
-import udatetime
-
 from rets.errors import RetsParseError
 
 logger = logging.getLogger('rets')
@@ -78,7 +76,7 @@ def _decode_datetime(value: str, include_tz: bool) -> datetime:
     elif value[10] == ' ':
         value = '%sT%s' % (value[0:10], value[11:])
 
-    decoded = udatetime.from_string(value)
+    datetime.strptime(value, '%Y-%m-%dT%H:%M:%S')
     if not include_tz:
         return decoded.astimezone(timezone.utc).replace(tzinfo=None)
     return decoded

--- a/rets/http/client.py
+++ b/rets/http/client.py
@@ -232,6 +232,7 @@ class RetsHttpClient:
                    resource_keys: Union[str, Mapping[str, Any], Sequence[str]],
                    media_types: Union[str, Sequence[str]] = '*/*',
                    location: bool = False,
+                   default_encoding: bool = False,
                    ) -> Sequence[Object]:
         """
         The GetObject transaction is used to retrieve structured information related to known
@@ -282,7 +283,7 @@ class RetsHttpClient:
             'Location': int(location),
         }
         response = self._http_request(self._url_for('GetObject'), headers=headers, payload=payload)
-        return parse_object(response)
+        return parse_object(response, default_encoding)
 
     def _url_for(self, transaction: str) -> str:
         try:

--- a/rets/http/client.py
+++ b/rets/http/client.py
@@ -224,7 +224,7 @@ class RetsHttpClient:
         payload = {k: v for k, v in raw_payload.items() if v is not None}
 
         response = self._http_request(self._url_for('Search'), payload=payload)
-        return parse_search(response)
+        return parse_search(response, format_)
 
     def get_object(self,
                    resource: str,

--- a/rets/http/parsers/parse.py
+++ b/rets/http/parsers/parse.py
@@ -8,6 +8,7 @@ from requests_toolbelt.multipart.decoder import BodyPart
 
 from rets.errors import RetsParseError, RetsApiError, RetsResponseError
 from rets.http.data import Metadata, SearchResult, SystemMetadata
+import xmltodict
 
 DEFAULT_ENCODING = 'utf-8'
 
@@ -128,7 +129,7 @@ def parse_system(response: Response) -> SystemMetadata:
     )
 
 
-def parse_search(response: Response) -> SearchResult:
+def parse_search(response: Response, format_: str = 'COMPACT-DECODED') -> SearchResult:
     try:
         elem = parse_xml(response)
     except RetsApiError as e:
@@ -142,10 +143,13 @@ def parse_search(response: Response) -> SearchResult:
     else:
         count = None
 
-    try:
-        data = tuple(_parse_data(elem))
-    except RetsParseError:
-        data = None
+    if format_ == 'STANDARD-XML':
+        data = xmltodict.parse(response.content)
+    else:
+        try:
+            data = tuple(_parse_data(elem))
+        except RetsParseError:
+            data = None
 
     return SearchResult(
         count=count,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ long_desc = 'Python 3 client for the Real Estate Transaction Standard (RETS) Ver
 install_requires = [
     'requests>=2.12.3',
     'requests-toolbelt>=0.7.0,!=0.9.0',
-    'udatetime==0.0.16',
     'docopts',
     'lxml>=4.3.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ install_requires = [
     'requests-toolbelt>=0.7.0,!=0.9.0',
     'docopts',
     'lxml>=4.3.0',
+    'xmltodict>=0.12.0',
 ]
 
 setup_requires = [


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

Enable flag to use default encoding rather than the response encoding from payload

> Why are you making this change?

For certain MLS's, the response.encoding does match the content returned

https://luxurypresence.atlassian.net/browse/DATA-680
## Summary of Changes
Add parameter to be passed

## Test Plan

For Spark - Gcar, it needs to be able to successfully download of its images