### PR TITLE
Update udatetime to 0.0.17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_desc = 'Python 3 client for the Real Estate Transaction Standard (RETS) Ver
 install_requires = [
     'requests>=2.12.3',
     'requests-toolbelt>=0.7.0,!=0.9.0',
-    'udatetime==0.0.16',
+    'udatetime==0.0.17',
     'lxml>=4.3.0',
 ]
 


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

Closes #59 

Updated udatetime dependency to 0.0.17 to be able to build this repo on newer versions of Python (tested on 3.10)

## Test Plan

I've run this on Python3.10, retrieved some items from a MLS and ensured that datetime fields are parsed and parsed correctly. 
There are no major changes to the udatetime library, so, IMO, this will do.

Also I've run tests and they passed:

```
================================ test session starts =================================
platform linux -- Python 3.10.5, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/olekthunder/git-repos/opendoor-rets
collected 25 items

tests/client/decoder_test.py ......                                            [ 24%]
tests/client/http_client_test.py .                                             [ 28%]
tests/client/request_test.py ..                                                [ 36%]
tests/http/parsers/parse_multipart_test.py .......                             [ 64%]
tests/http/parsers/parse_object_test.py .........                              [100%]

================================= 25 passed in 0.14s =================================
```
## Checklist

<!-- This is a checklist. To mark an item as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to external documentation if necessary (READMEs, Confluence, etc.)
- [x] I have checked that other PRs this PR depends on have already been deployed.

<!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->
